### PR TITLE
Use correct monster IDs in Chortos-2 and Takatomon links

### DIFF
--- a/src/utility/resource_loader.tsx
+++ b/src/utility/resource_loader.tsx
@@ -123,25 +123,38 @@ export function ObtainLegacySkill(userMonsterId: string, userMonsterList: types.
 export function ObtainChortosLink(monsterId: string, monsterData: types.IMonsterData[]) {
     const BASE_URL = "https://chortos.selfip.net/digimonlinks/monsters/";
 
-    const group = monsterData.find(m => m.monsterId === monsterId);
+    const monster = monsterData.find(m => m.monsterId === monsterId);
 
-    if (!group) {
+    if (!monster) {
         return "";
     }
 
-    return BASE_URL + group.monsterGroupId;
+    const group = monsterInfo.find(m => m.monsterGroupId === monster.monsterGroupId);
+
+    if (!group || group.monsterCollectionId === "0" || group.monsterCollectionId.length !== 5) {
+        return BASE_URL + monster.monsterGroupId;
+    } else {
+        return BASE_URL + parseInt(group.monsterCollectionId.substring(1));
+    }
 }
 
 export function ObtainTakatomonLink(monsterId: string, monsterData: types.IMonsterData[]) {
     const BASE_URL = "https://takatomon.net/?sd=";
 
-    const group = monsterData.find(m => m.monsterId === monsterId);
+    const monster = monsterData.find(m => m.monsterId === monsterId);
 
-    if (!group) {
+    if (!monster) {
         return "";
     }
 
-    return BASE_URL + group.monsterGroupId;
+    const group = monsterInfo.find(m => m.monsterGroupId === monster.monsterGroupId);
+
+    // Exclude mutants
+    if (!group || group.monsterCollectionId === "0" || group.monsterCollectionId.length !== 5) {
+        return "";
+    }
+
+    return BASE_URL + parseInt(group.monsterCollectionId.substring(1));
 }
 
 export function ObtainEvolutionInformation(


### PR DESCRIPTION
The numbering they (we—Iʼm Chortos-2) use is based on `monsterCollectionId` where available. In particular, this currently differs from `monsterGroupId` for Armagemon, Omegamon MM and Volcanicdramon's varoius attribute variants.

Furthermore, Takatomon does not show monsters that are mutants or have zero `monsterCollectionId`. Don’t form Takatomon links for them.

It is my understanding (based on reading the code) that Chortos-2 and Takatomon links are shown for all monsters regardless of the success of the `Obtain*Link` calls—they just don’t work if the URLs weren’t generated. I think the links shouldn’t be shown at all in this case, but this commit makes no attempt to hide them.